### PR TITLE
Combine movie details and overview fetching 

### DIFF
--- a/MovieApp/MovieApp.xcodeproj/project.pbxproj
+++ b/MovieApp/MovieApp.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		6397421D26CD3EF900A2D0B1 /* UIControl+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6397421C26CD3EF900A2D0B1 /* UIControl+Combine.swift */; };
 		6397421F26CD3EFF00A2D0B1 /* UIView+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6397421E26CD3EFF00A2D0B1 /* UIView+Combine.swift */; };
 		6397422126CD3F4000A2D0B1 /* UIBarButtonItem+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6397422026CD3F4000A2D0B1 /* UIBarButtonItem+Extensions.swift */; };
+		6397422326CE569100A2D0B1 /* UserDefaults+key.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6397422226CE569100A2D0B1 /* UserDefaults+key.swift */; };
 		63A8E41126CBE4F000783D31 /* CrewGridCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A8E41026CBE4F000783D31 /* CrewGridCollectionView.swift */; };
 		63A8E41326CBE50100783D31 /* CrewGridCollectionView+Design.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A8E41226CBE50100783D31 /* CrewGridCollectionView+Design.swift */; };
 		63BD081026A1C30900AF366A /* NetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63BD080F26A1C30900AF366A /* NetworkClient.swift */; };
@@ -236,6 +237,7 @@
 		6397421C26CD3EF900A2D0B1 /* UIControl+Combine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIControl+Combine.swift"; sourceTree = "<group>"; };
 		6397421E26CD3EFF00A2D0B1 /* UIView+Combine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Combine.swift"; sourceTree = "<group>"; };
 		6397422026CD3F4000A2D0B1 /* UIBarButtonItem+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+Extensions.swift"; sourceTree = "<group>"; };
+		6397422226CE569100A2D0B1 /* UserDefaults+key.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+key.swift"; sourceTree = "<group>"; };
 		63A8E41026CBE4F000783D31 /* CrewGridCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrewGridCollectionView.swift; sourceTree = "<group>"; };
 		63A8E41226CBE50100783D31 /* CrewGridCollectionView+Design.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CrewGridCollectionView+Design.swift"; sourceTree = "<group>"; };
 		63BD080F26A1C30900AF366A /* NetworkClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkClient.swift; sourceTree = "<group>"; };
@@ -427,6 +429,7 @@
 				6397422026CD3F4000A2D0B1 /* UIBarButtonItem+Extensions.swift */,
 				63019A2926B17AC200584356 /* UIStackView.swift */,
 				630CDD6826B4330E0052D290 /* UILabel+setLineSpacing.swift */,
+				6397422226CE569100A2D0B1 /* UserDefaults+key.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -925,6 +928,7 @@
 				631628C626C26390009299C5 /* UserDefaultsDataSourceProtocol.swift in Sources */,
 				633E7E9A26A942CD0091322D /* GenreView.swift in Sources */,
 				630CDD9A26BA84170052D290 /* ReviewResponse.swift in Sources */,
+				6397422326CE569100A2D0B1 /* UserDefaults+key.swift in Sources */,
 				6397421D26CD3EF900A2D0B1 /* UIControl+Combine.swift in Sources */,
 				630CDD8826B824FF0052D290 /* ReviewViewModel.swift in Sources */,
 				633E7EA526A96D140091322D /* FavouriteButton.swift in Sources */,

--- a/MovieApp/MovieApp/App/Core/Combine/Publisher+Extensions.swift
+++ b/MovieApp/MovieApp/App/Core/Combine/Publisher+Extensions.swift
@@ -1,5 +1,5 @@
-import Foundation
 import Combine
+import Foundation
 
 extension Publisher {
 

--- a/MovieApp/MovieApp/App/CoreUI/Extensions/UIView+Combine.swift
+++ b/MovieApp/MovieApp/App/CoreUI/Extensions/UIView+Combine.swift
@@ -1,5 +1,5 @@
-import UIKit
 import Combine
+import UIKit
 
 extension UIView {
 

--- a/MovieApp/MovieApp/App/CoreUI/Extensions/UserDefaults+key.swift
+++ b/MovieApp/MovieApp/App/CoreUI/Extensions/UserDefaults+key.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension UserDefaults {
+    
+    @objc dynamic var favorites: [Int] {
+        array(forKey: "favorites") as? [Int] ?? []
+    }
+    
+}

--- a/MovieApp/MovieApp/App/Features/MovieBrowser/Components/DetailScreen/TitleView/DetailTitleView.swift
+++ b/MovieApp/MovieApp/App/Features/MovieBrowser/Components/DetailScreen/TitleView/DetailTitleView.swift
@@ -26,7 +26,6 @@ class DetailTitleView: UIView {
     }
     
     public var favoritePressed: (() -> ())!
-    public var checkIfFavorite: (() -> Bool)!
         
     init() {
         super.init(frame: .zero)
@@ -63,10 +62,6 @@ class DetailTitleView: UIView {
     
     @objc func favoriteButtonPressed() {
         favoritePressed()
-    }
-    
-    func reloadData() {
-        isFavorite = checkIfFavorite()
     }
     
 }

--- a/MovieApp/MovieApp/App/Features/MovieBrowser/MoviesViewController/MovieDetail/MovieDetailPresenter.swift
+++ b/MovieApp/MovieApp/App/Features/MovieBrowser/MoviesViewController/MovieDetail/MovieDetailPresenter.swift
@@ -10,10 +10,6 @@ final class MovieDetailPresenter {
     
     let movieId: Int!
     
-    var isFavorite: Bool {
-        useCase.checkIfFavorite(for: movieId)
-    }
-    
     init (useCase: MoviesUseCaseProtocol, router: AppRouter, for movieId: Int) {
         self.useCase = useCase
         self.router = router
@@ -45,11 +41,11 @@ final class MovieDetailPresenter {
 //            }
 //        }
 //    }
-    var movieDetails: AnyPublisher<DetailTitleViewModel, RequestError> {
+    var movieDetails: AnyPublisher<DetailTitleViewModel, Never> {
         useCase
             .getMovieDetails(for: movieId)
             .map { DetailTitleViewModel(fromModel: $0) }
-            .eraseToAnyPublisher()
+            .receiveOnMain()
     }
     
 //    func getOverview() {
@@ -64,10 +60,6 @@ final class MovieDetailPresenter {
 //            }
 //        }
 //    }
-    var overview: AnyPublisher<String, RequestError> {
-        useCase
-            .getMovieOverview(for: movieId)
-    }
 
     
     func getMostPopularCast() {

--- a/MovieApp/MovieApp/App/Features/MovieBrowser/MoviesViewController/MovieDetail/MovieDetailPresenter.swift
+++ b/MovieApp/MovieApp/App/Features/MovieBrowser/MoviesViewController/MovieDetail/MovieDetailPresenter.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import UIKit
 
@@ -24,39 +25,50 @@ final class MovieDetailPresenter {
     }
     
     func fetchAll() {
-        getMovieDetails()
-        getOverview()
+        //getMovieDetails()
+        //getOverview()
         getMostPopularCast()
         getCrew()
         getRecommendations()
         getReview()
     }
     
-    func getMovieDetails() {
-        useCase.getMovieDetails(for: movieId) { [weak self] result in
-            guard let self = self else { return }
-            
-            switch result {
-            case .success(let movie):
-                self.delegate?.fillDetailTitleView(with: DetailTitleViewModel(fromModel: movie))
-            case .failure(let error):
-                print("Loading error: \(error.localizedDescription)")
-            }
-        }
+//    func getMovieDetails() {
+//        useCase.getMovieDetails(for: movieId) { [weak self] result in
+//            guard let self = self else { return }
+//
+//            switch result {
+//            case .success(let movie):
+//                self.delegate?.fillDetailTitleView(with: DetailTitleViewModel(fromModel: movie))
+//            case .failure(let error):
+//                print("Loading error: \(error.localizedDescription)")
+//            }
+//        }
+//    }
+    var movieDetails: AnyPublisher<DetailTitleViewModel, RequestError> {
+        useCase
+            .getMovieDetails(for: movieId)
+            .map { DetailTitleViewModel(fromModel: $0) }
+            .eraseToAnyPublisher()
     }
     
-    func getOverview() {
-        useCase.getMovieOverview(for: movieId) { [weak self] result in
-            guard let self = self else { return }
-            
-            switch result {
-            case .success(let overview):
-                self.delegate?.fillOverview(with: overview)
-            case .failure(let error):
-                print("Loading error: \(error.localizedDescription)")
-            }
-        }
+//    func getOverview() {
+//        useCase.getMovieOverview(for: movieId) { [weak self] result in
+//            guard let self = self else { return }
+//
+//            switch result {
+//            case .success(let overview):
+//                self.delegate?.fillOverview(with: overview)
+//            case .failure(let error):
+//                print("Loading error: \(error.localizedDescription)")
+//            }
+//        }
+//    }
+    var overview: AnyPublisher<String, RequestError> {
+        useCase
+            .getMovieOverview(for: movieId)
     }
+
     
     func getMostPopularCast() {
         useCase.getMostPopularCast(for: movieId) { [weak self] result in

--- a/MovieApp/MovieApp/App/Features/MovieBrowser/MoviesViewController/MovieDetail/MovieDetailViewController+Design.swift
+++ b/MovieApp/MovieApp/App/Features/MovieBrowser/MoviesViewController/MovieDetail/MovieDetailViewController+Design.swift
@@ -21,11 +21,6 @@ extension MovieDetailViewController: DesignProtocol {
             
             self.presenter.favoritePressed()
         }
-        titleView.checkIfFavorite = { [weak self] in
-            guard let self = self else { return false }
-            
-            return self.presenter.isFavorite
-        }
         contentView.addSubview(titleView)
         
         overviewTitle = UILabel()

--- a/MovieApp/MovieApp/App/Features/MovieBrowser/MoviesViewController/MovieDetail/MovieDetailViewController.swift
+++ b/MovieApp/MovieApp/App/Features/MovieBrowser/MoviesViewController/MovieDetail/MovieDetailViewController.swift
@@ -1,3 +1,4 @@
+import Combine
 import UIKit
 
 class MovieDetailViewController: UIViewController {
@@ -5,6 +6,8 @@ class MovieDetailViewController: UIViewController {
     let offset: CGFloat = 4
         
     var presenter: MovieDetailPresenter!
+    
+    var disposables = Set<AnyCancellable>()
     
     var scrollView: UIScrollView!
     var contentView: UIView!
@@ -33,6 +36,28 @@ class MovieDetailViewController: UIViewController {
         buildViews()
         
         presenter.fetchAll()
+        
+        presenter
+            .movieDetails
+            .sink(
+                receiveCompletion: { print("Ended with ", $0)},
+                receiveValue: { movie in
+                    DispatchQueue.main.async {
+                        self.titleView.populate(with: movie)
+                    }
+                })
+            .store(in: &disposables)
+        
+        presenter
+            .overview
+            .sink(
+                receiveCompletion: { print("Ended with ", $0)},
+                receiveValue: { text in
+                    DispatchQueue.main.async {
+                        self.overview.text = text
+                    }
+                })
+            .store(in: &disposables)
     }
 
 }

--- a/MovieApp/MovieApp/App/Features/MovieBrowser/MoviesViewController/MovieDetail/MovieDetailViewController.swift
+++ b/MovieApp/MovieApp/App/Features/MovieBrowser/MoviesViewController/MovieDetail/MovieDetailViewController.swift
@@ -37,27 +37,21 @@ class MovieDetailViewController: UIViewController {
         
         presenter.fetchAll()
         
+        bindViews()
+    }
+    
+    private func bindViews() {
         presenter
             .movieDetails
-            .sink(
-                receiveCompletion: { print("Ended with ", $0)},
-                receiveValue: { movie in
-                    DispatchQueue.main.async {
-                        self.titleView.populate(with: movie)
-                    }
-                })
+            .sink { [weak self] in
+                self?.setData($0)
+            }
             .store(in: &disposables)
-        
-        presenter
-            .overview
-            .sink(
-                receiveCompletion: { print("Ended with ", $0)},
-                receiveValue: { text in
-                    DispatchQueue.main.async {
-                        self.overview.text = text
-                    }
-                })
-            .store(in: &disposables)
+    }
+    
+    private func setData(_ data: DetailTitleViewModel) {
+        titleView.populate(with: data)
+        overview.text = data.overview
     }
 
 }
@@ -86,7 +80,7 @@ extension MovieDetailViewController: MovieDetailDelegate {
     }
     
     func reloadData() {
-        titleView.reloadData()
+        //titleView.reloadData()
     }
     
     func fillCrew(with crew: [CrewViewModel]) {

--- a/MovieApp/MovieApp/App/Features/MovieBrowser/MoviesViewController/ViewModels/DetailTitleViewModel.swift
+++ b/MovieApp/MovieApp/App/Features/MovieBrowser/MoviesViewController/ViewModels/DetailTitleViewModel.swift
@@ -3,6 +3,7 @@ import Foundation
 struct DetailTitleViewModel {
     
     let title: String
+    let overview: String
     let year: String
     let releaseDate: String
     let genres: [String]
@@ -30,6 +31,7 @@ extension DetailTitleViewModel {
         
         self.init(
             title: model.title,
+            overview: model.overview,
             year: year,
             releaseDate: dateString,
             genres: model.genreIds!.map { Genre(rawValue: $0)?.genreName ?? "" },

--- a/MovieApp/MovieApp/App/Features/MovieBrowser/NetworkClient/MovieClient.swift
+++ b/MovieApp/MovieApp/App/Features/MovieBrowser/NetworkClient/MovieClient.swift
@@ -52,7 +52,7 @@ class MovieClient: MovieClientProtocol {
             .map { $0.data }
             .decode(type: MovieDetailResponse.self, decoder: JSONDecoder())
             .assertNoFailure()
-            .subscribeOnBackground()
+            .eraseToAnyPublisher()
     }
     
     func fetchCast(for movieId: Int, completion: @escaping(Result<[CastResponse], RequestError>) -> Void) {

--- a/MovieApp/MovieApp/App/Features/MovieBrowser/NetworkClient/MovieClient.swift
+++ b/MovieApp/MovieApp/App/Features/MovieBrowser/NetworkClient/MovieClient.swift
@@ -52,8 +52,7 @@ class MovieClient: MovieClientProtocol {
             .map { $0.data }
             .decode(type: MovieDetailResponse.self, decoder: JSONDecoder())
             .assertNoFailure()
-            .print()
-            .eraseToAnyPublisher()
+            .subscribeOnBackground()
     }
     
     func fetchCast(for movieId: Int, completion: @escaping(Result<[CastResponse], RequestError>) -> Void) {

--- a/MovieApp/MovieApp/App/Features/MovieBrowser/NetworkClient/MovieClient.swift
+++ b/MovieApp/MovieApp/App/Features/MovieBrowser/NetworkClient/MovieClient.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import Alamofire
 
@@ -35,10 +36,23 @@ class MovieClient: MovieClientProtocol {
         }
     }
     
-    func fetchMovieDetails(for movieId: Int, completion: @escaping(Result<MovieDetailResponse, RequestError>) -> Void) {
-        fetch(forUrl: "movie/\(movieId)") { (result: Result<MovieDetailResponse, RequestError>) in
-            completion(result)
+//    func fetchMovieDetails(for movieId: Int, completion: @escaping(Result<MovieDetailResponse, RequestError>) -> Void) {
+//        fetch(forUrl: "movie/\(movieId)") { (result: Result<MovieDetailResponse, RequestError>) in
+//            completion(result)
+//        }
+//    }
+    
+    func fetchMovieDetails(for movieId: Int) -> AnyPublisher<MovieDetailResponse, RequestError> {
+        guard let url = URL(string: "https://api.themoviedb.org/3/movie/\(movieId)?api_key=ca4ebd2878172f71e1cfb5b5f748f928&language=en-US")
+        else {
+            return Fail(error: RequestError.invalidEndpoint).eraseToAnyPublisher()
         }
+        
+        return URLSession.shared.dataTaskPublisher(for: url)
+            .map { $0.data }
+            .decode(type: MovieDetailResponse.self, decoder: JSONDecoder())
+            .mapError { self.mapError($0) }
+            .eraseToAnyPublisher()
     }
     
     func fetchCast(for movieId: Int, completion: @escaping(Result<[CastResponse], RequestError>) -> Void) {
@@ -108,6 +122,34 @@ extension MovieClient {
                 completion(.success(value))
             }
         }
+    }
+    
+}
+
+extension MovieClient {
+    
+    private func mapError(_ error: AFError) -> RequestError {
+        switch error {
+        case .createURLRequestFailed(error: _),
+             .urlRequestValidationFailed(reason: _):
+            return .invalidRequest
+        case .invalidURL(url: _):
+            return .invalidEndpoint
+        case .responseValidationFailed(reason: _),
+             .responseSerializationFailed(reason: _):
+            return .invalidResponse
+        case .serverTrustEvaluationFailed(reason: _),
+             .sessionDeinitialized,
+             .sessionInvalidated(error: _),
+             .sessionTaskFailed(error: _):
+            return .apiError
+        default:
+            return .general
+        }
+    }
+    
+    private func mapError(_ error: Error) -> RequestError {
+        .invalidRequest
     }
     
 }

--- a/MovieApp/MovieApp/App/Features/MovieBrowser/NetworkClient/MovieClient.swift
+++ b/MovieApp/MovieApp/App/Features/MovieBrowser/NetworkClient/MovieClient.swift
@@ -42,16 +42,17 @@ class MovieClient: MovieClientProtocol {
 //        }
 //    }
     
-    func fetchMovieDetails(for movieId: Int) -> AnyPublisher<MovieDetailResponse, RequestError> {
+    func fetchMovieDetails(for movieId: Int) -> AnyPublisher<MovieDetailResponse, Never> {
         guard let url = URL(string: "https://api.themoviedb.org/3/movie/\(movieId)?api_key=ca4ebd2878172f71e1cfb5b5f748f928&language=en-US")
         else {
-            return Fail(error: RequestError.invalidEndpoint).eraseToAnyPublisher()
+            return .empty()
         }
         
         return URLSession.shared.dataTaskPublisher(for: url)
             .map { $0.data }
             .decode(type: MovieDetailResponse.self, decoder: JSONDecoder())
-            .mapError { self.mapError($0) }
+            .assertNoFailure()
+            .print()
             .eraseToAnyPublisher()
     }
     

--- a/MovieApp/MovieApp/App/Features/MovieBrowser/NetworkClient/MovieClientProtocol.swift
+++ b/MovieApp/MovieApp/App/Features/MovieBrowser/NetworkClient/MovieClientProtocol.swift
@@ -1,3 +1,5 @@
+import Combine
+
 protocol MovieClientProtocol {
     
     func fetchPopularMovies(completion: @escaping(Result<[MovieResponse], RequestError>) -> Void)
@@ -10,7 +12,8 @@ protocol MovieClientProtocol {
     
     func fetchTopRatedTV(completion: @escaping(Result<[TVShowResponse], RequestError>) -> Void)
     
-    func fetchMovieDetails(for movieId: Int, completion: @escaping(Result<MovieDetailResponse, RequestError>) -> Void)
+    //func fetchMovieDetails(for movieId: Int, completion: @escaping(Result<MovieDetailResponse, RequestError>) -> Void)
+    func fetchMovieDetails(for movieId: Int) -> AnyPublisher<MovieDetailResponse, RequestError>
     
     func fetchCast(for movieId: Int, completion: @escaping(Result<[CastResponse], RequestError>) -> Void)
     

--- a/MovieApp/MovieApp/App/Features/MovieBrowser/NetworkClient/MovieClientProtocol.swift
+++ b/MovieApp/MovieApp/App/Features/MovieBrowser/NetworkClient/MovieClientProtocol.swift
@@ -13,7 +13,7 @@ protocol MovieClientProtocol {
     func fetchTopRatedTV(completion: @escaping(Result<[TVShowResponse], RequestError>) -> Void)
     
     //func fetchMovieDetails(for movieId: Int, completion: @escaping(Result<MovieDetailResponse, RequestError>) -> Void)
-    func fetchMovieDetails(for movieId: Int) -> AnyPublisher<MovieDetailResponse, RequestError>
+    func fetchMovieDetails(for movieId: Int) -> AnyPublisher<MovieDetailResponse, Never>
     
     func fetchCast(for movieId: Int, completion: @escaping(Result<[CastResponse], RequestError>) -> Void)
     

--- a/MovieApp/MovieApp/App/LocalDataSource/UserDefaultsDataSource.swift
+++ b/MovieApp/MovieApp/App/LocalDataSource/UserDefaultsDataSource.swift
@@ -19,7 +19,7 @@ class UserDefaultsDataSource: UserDefaultsDataSourceProtocol {
         UserDefaults
             .standard
             .publisher(for: \.favorites)
-            .eraseToAnyPublisher()
+            .receiveOnBackground()
     }
     
     func toggleFavorite(_ movieId: Int) {

--- a/MovieApp/MovieApp/App/LocalDataSource/UserDefaultsDataSource.swift
+++ b/MovieApp/MovieApp/App/LocalDataSource/UserDefaultsDataSource.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 
 class UserDefaultsDataSource: UserDefaultsDataSourceProtocol {
@@ -6,12 +7,19 @@ class UserDefaultsDataSource: UserDefaultsDataSourceProtocol {
     
     private let favoritesUDKey = "favorites"
     
-    var favorites: [Int] {
-        if let favorites = UserDefaults.standard.object(forKey: favoritesUDKey) as? [Int] {
-            return favorites
-        } else {
-            return []
-        }
+//    var favorites: [Int] {
+//        if let favorites = UserDefaults.standard.object(forKey: favoritesUDKey) as? [Int] {
+//            return favorites
+//        } else {
+//            return []
+//        }
+//    }
+    
+    var favorites: AnyPublisher<[Int], Never> {
+        UserDefaults
+            .standard
+            .publisher(for: \.favorites)
+            .subscribeOnBackground()
     }
     
     func toggleFavorite(_ movieId: Int) {
@@ -20,7 +28,7 @@ class UserDefaultsDataSource: UserDefaultsDataSourceProtocol {
             return
         }
         
-        if isFavorite(movieId: movieId) {
+        if favorites.contains(movieId) {
             favorites.removeAll { $0 == movieId }
         } else {
             favorites.append(movieId)
@@ -28,8 +36,8 @@ class UserDefaultsDataSource: UserDefaultsDataSourceProtocol {
         UserDefaults.standard.setValue(favorites, forKey: favoritesUDKey)
     }
     
-    func isFavorite(movieId: Int) -> Bool {
-        favorites.contains(movieId)
-    }
+//    func isFavorite(movieId: Int) -> Bool {
+//        favorites.contains(movieId)
+//    }
     
 }

--- a/MovieApp/MovieApp/App/LocalDataSource/UserDefaultsDataSource.swift
+++ b/MovieApp/MovieApp/App/LocalDataSource/UserDefaultsDataSource.swift
@@ -19,7 +19,7 @@ class UserDefaultsDataSource: UserDefaultsDataSourceProtocol {
         UserDefaults
             .standard
             .publisher(for: \.favorites)
-            .subscribeOnBackground()
+            .eraseToAnyPublisher()
     }
     
     func toggleFavorite(_ movieId: Int) {

--- a/MovieApp/MovieApp/App/LocalDataSource/UserDefaultsDataSource.swift
+++ b/MovieApp/MovieApp/App/LocalDataSource/UserDefaultsDataSource.swift
@@ -19,7 +19,7 @@ class UserDefaultsDataSource: UserDefaultsDataSourceProtocol {
         UserDefaults
             .standard
             .publisher(for: \.favorites)
-            .receiveOnBackground()
+            .eraseToAnyPublisher()
     }
     
     func toggleFavorite(_ movieId: Int) {

--- a/MovieApp/MovieApp/App/LocalDataSource/UserDefaultsDataSourceProtocol.swift
+++ b/MovieApp/MovieApp/App/LocalDataSource/UserDefaultsDataSourceProtocol.swift
@@ -1,9 +1,9 @@
+import Combine
+
 protocol UserDefaultsDataSourceProtocol {
     
-    var favorites: [Int] { get }
+    var favorites: AnyPublisher<[Int], Never> { get }
     
     func toggleFavorite(_ movieId: Int)
-    
-    func isFavorite(movieId: Int) -> Bool 
-    
+        
 }

--- a/MovieApp/MovieApp/App/NetworkDataSource/MovieNetworkDataSource.swift
+++ b/MovieApp/MovieApp/App/NetworkDataSource/MovieNetworkDataSource.swift
@@ -1,3 +1,5 @@
+import Combine
+
 class MovieNetworkDataSource: MovieNetworkDataSourceProtocol {
     
     static let shared: MovieNetworkDataSourceProtocol = MovieNetworkDataSource()
@@ -44,10 +46,17 @@ class MovieNetworkDataSource: MovieNetworkDataSourceProtocol {
         }
     }
     
-    func fetchMovieDetails(for movieId: Int, completion: @escaping(Result<MovieDataModel, RequestError>) -> Void) {
-        movieClient.fetchMovieDetails(for: movieId) { [weak self] result in
-            self?.mapMovieDetailResult(result: result, completion: completion)
-        }
+//    func fetchMovieDetails(for movieId: Int, completion: @escaping(Result<MovieDataModel, RequestError>) -> Void) {
+//        movieClient.fetchMovieDetails(for: movieId) { [weak self] result in
+//            self?.mapMovieDetailResult(result: result, completion: completion)
+//        }
+//    }
+    
+    func fetchMovieDetails(for movieId: Int) -> AnyPublisher<MovieDataModel, RequestError> {
+        movieClient
+            .fetchMovieDetails(for: movieId)
+            .map { MovieDataModel(fromModel: $0) }
+            .eraseToAnyPublisher()
     }
     
     func fetchCast(for movieId: Int, completion: @escaping(Result<[CastDataModel], RequestError>) -> Void) {

--- a/MovieApp/MovieApp/App/NetworkDataSource/MovieNetworkDataSource.swift
+++ b/MovieApp/MovieApp/App/NetworkDataSource/MovieNetworkDataSource.swift
@@ -52,10 +52,12 @@ class MovieNetworkDataSource: MovieNetworkDataSourceProtocol {
 //        }
 //    }
     
-    func fetchMovieDetails(for movieId: Int) -> AnyPublisher<MovieDataModel, RequestError> {
+    func fetchMovieDetails(for movieId: Int) -> AnyPublisher<MovieDataModel, Never> {
         movieClient
             .fetchMovieDetails(for: movieId)
-            .map { MovieDataModel(fromModel: $0) }
+            .map {
+                print("Network DS -> ", $0)
+                return MovieDataModel(fromModel: $0) }
             .eraseToAnyPublisher()
     }
     

--- a/MovieApp/MovieApp/App/NetworkDataSource/MovieNetworkDataSource.swift
+++ b/MovieApp/MovieApp/App/NetworkDataSource/MovieNetworkDataSource.swift
@@ -55,9 +55,7 @@ class MovieNetworkDataSource: MovieNetworkDataSourceProtocol {
     func fetchMovieDetails(for movieId: Int) -> AnyPublisher<MovieDataModel, Never> {
         movieClient
             .fetchMovieDetails(for: movieId)
-            .map {
-                print("Network DS -> ", $0)
-                return MovieDataModel(fromModel: $0) }
+            .map { MovieDataModel(fromModel: $0) }
             .eraseToAnyPublisher()
     }
     

--- a/MovieApp/MovieApp/App/NetworkDataSource/MovieNetworkDataSourceProtocol.swift
+++ b/MovieApp/MovieApp/App/NetworkDataSource/MovieNetworkDataSourceProtocol.swift
@@ -1,3 +1,5 @@
+import Combine
+
 protocol MovieNetworkDataSourceProtocol {
     
     func fetchPopularMovies(completion: @escaping (Result<[MovieDataModel], RequestError>) -> Void)
@@ -10,7 +12,8 @@ protocol MovieNetworkDataSourceProtocol {
     
     func fetchTopRatedTV(completion: @escaping(Result<[MovieDataModel], RequestError>) -> Void)
     
-    func fetchMovieDetails(for movieId: Int, completion: @escaping(Result<MovieDataModel, RequestError>) -> Void)
+    //func fetchMovieDetails(for movieId: Int, completion: @escaping(Result<MovieDataModel, RequestError>) -> Void)
+    func fetchMovieDetails(for movieId: Int) -> AnyPublisher<MovieDataModel, RequestError>
     
     func fetchCast(for movieId: Int, completion: @escaping(Result<[CastDataModel], RequestError>) -> Void)
     

--- a/MovieApp/MovieApp/App/NetworkDataSource/MovieNetworkDataSourceProtocol.swift
+++ b/MovieApp/MovieApp/App/NetworkDataSource/MovieNetworkDataSourceProtocol.swift
@@ -13,7 +13,7 @@ protocol MovieNetworkDataSourceProtocol {
     func fetchTopRatedTV(completion: @escaping(Result<[MovieDataModel], RequestError>) -> Void)
     
     //func fetchMovieDetails(for movieId: Int, completion: @escaping(Result<MovieDataModel, RequestError>) -> Void)
-    func fetchMovieDetails(for movieId: Int) -> AnyPublisher<MovieDataModel, RequestError>
+    func fetchMovieDetails(for movieId: Int) -> AnyPublisher<MovieDataModel, Never>
     
     func fetchCast(for movieId: Int, completion: @escaping(Result<[CastDataModel], RequestError>) -> Void)
     

--- a/MovieApp/MovieApp/App/Networking/NetworkClient.swift
+++ b/MovieApp/MovieApp/App/Networking/NetworkClient.swift
@@ -13,7 +13,7 @@ class NetworkClient: NetworkClientProtocol {
     ) where T : Decodable {
         AF.request("https://api.themoviedb.org/3/\(urlPath)", method: method, parameters: parameters).responseJSON { (data) in
             guard let data = data.data else { return }
-            
+
             do {
                 let decodedData = try JSONDecoder().decode(T.self, from: data)
                 completion(.success(decodedData))

--- a/MovieApp/MovieApp/App/Repository/MovieRepository.swift
+++ b/MovieApp/MovieApp/App/Repository/MovieRepository.swift
@@ -35,7 +35,7 @@ class MovieRepository: MovieRepositoryProtocol {
                 let mappedMovies: [MovieRepoModel] = movies.map {
                     MovieRepoModel(
                         fromModel: $0,
-                        isFavorite: self.userDefaultsDataSource.isFavorite(movieId: $0.identifier),
+                        isFavorite: false,//self.userDefaultsDataSource.isFavorite(movieId: $0.identifier),
                         withGenre: Genre.day.rawValue)
                 }
                 if today, week {
@@ -56,7 +56,7 @@ class MovieRepository: MovieRepositoryProtocol {
                 let mappedMovies: [MovieRepoModel] = movies.map {
                     MovieRepoModel(
                         fromModel: $0,
-                        isFavorite: self?.userDefaultsDataSource.isFavorite(movieId: $0.identifier) ?? false,
+                        isFavorite: false,//self?.userDefaultsDataSource.isFavorite(movieId: $0.identifier) ?? false,
                         withGenre: Genre.week.rawValue)
                 }
                 if today, week {
@@ -83,10 +83,20 @@ class MovieRepository: MovieRepositoryProtocol {
 //        }
 //    }
     
-    func fetchMovieDetails(for movieId: Int) -> AnyPublisher<MovieRepoModel, RequestError> {
-        networkDataSource
+    func fetchMovieDetails(for movieId: Int) -> AnyPublisher<MovieRepoModel, Never> {
+        let userDefaultsPublisher = userDefaultsDataSource
+            .favorites
+            .print()
+            .eraseToAnyPublisher()
+        
+        return networkDataSource
             .fetchMovieDetails(for: movieId)
-            .map { MovieRepoModel(fromModel: $0) }
+            .combineLatest(userDefaultsPublisher)
+            .map { movie, favoriteArray -> MovieRepoModel in
+                let isFavorite = favoriteArray.contains(movie.identifier)
+                print("Repo -> ", movie)
+                return MovieRepoModel(fromModel: movie, isFavorite: isFavorite)
+            }
             .eraseToAnyPublisher()
     }
     
@@ -199,16 +209,10 @@ class MovieRepository: MovieRepositoryProtocol {
 //        }
         completion(.failure(.general))
     }
-    
+//
 //    var favoriteMovies: AnyPublisher<[MovieRepoModel], Never> {
 //
 //    }
-    
-    func checkIfFavorite(for movieId: Int) -> Bool {
-        userDefaultsDataSource
-            .favorites
-            .contains(movieId)
-    }
     
 }
 
@@ -222,7 +226,7 @@ extension MovieRepository {
         switch result {
         case .success(let movies):
             let mappedMovies: [MovieRepoModel] = movies.map {
-                MovieRepoModel(fromModel: $0, isFavorite: userDefaultsDataSource.isFavorite(movieId: $0.identifier))
+                MovieRepoModel(fromModel: $0, isFavorite: false)//userDefaultsDataSource.isFavorite(movieId: $0.identifier))
             }
             categoryMovies[category] = mappedMovies
             completion(.success(mappedMovies))
@@ -239,7 +243,7 @@ extension MovieRepository {
         case .success(let movie):
             let mappedMovie = MovieRepoModel(
                 fromModel: movie,
-                isFavorite: userDefaultsDataSource.favorites.contains(movie.identifier))
+                isFavorite: false)//userDefaultsDataSource.favorites.contains(movie.identifier))
             completion(.success(mappedMovie))
         case .failure(let error):
             completion(.failure(error))
@@ -250,7 +254,7 @@ extension MovieRepository {
         categoryMovies = categoryMovies
             .mapValues { categoryMovies in
                 categoryMovies
-                    .map { $0.copy(isFavorite: userDefaultsDataSource.favorites.contains($0.identifier)) }
+                    .map { $0.copy(isFavorite: false) }//userDefaultsDataSource.favorites.contains($0.identifier)) }
             }
     }
     

--- a/MovieApp/MovieApp/App/Repository/MovieRepository.swift
+++ b/MovieApp/MovieApp/App/Repository/MovieRepository.swift
@@ -86,7 +86,6 @@ class MovieRepository: MovieRepositoryProtocol {
     func fetchMovieDetails(for movieId: Int) -> AnyPublisher<MovieRepoModel, Never> {
         let userDefaultsPublisher = userDefaultsDataSource
             .favorites
-            .print()
             .eraseToAnyPublisher()
         
         return networkDataSource
@@ -94,7 +93,6 @@ class MovieRepository: MovieRepositoryProtocol {
             .combineLatest(userDefaultsPublisher)
             .map { movie, favoriteArray -> MovieRepoModel in
                 let isFavorite = favoriteArray.contains(movie.identifier)
-                print("Repo -> ", movie)
                 return MovieRepoModel(fromModel: movie, isFavorite: isFavorite)
             }
             .eraseToAnyPublisher()

--- a/MovieApp/MovieApp/App/Repository/MovieRepository.swift
+++ b/MovieApp/MovieApp/App/Repository/MovieRepository.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 
 class MovieRepository: MovieRepositoryProtocol {
@@ -76,10 +77,17 @@ class MovieRepository: MovieRepositoryProtocol {
         }
     }
     
-    func fetchMovieDetails(for movieId: Int, completion: @escaping(Result<MovieRepoModel, RequestError>) -> Void) {
-        networkDataSource.fetchMovieDetails(for: movieId) { [weak self] result in
-            self?.mapMovieDetailResult(result: result, completion: completion)
-        }
+//    func fetchMovieDetails(for movieId: Int, completion: @escaping(Result<MovieRepoModel, RequestError>) -> Void) {
+//        networkDataSource.fetchMovieDetails(for: movieId) { [weak self] result in
+//            self?.mapMovieDetailResult(result: result, completion: completion)
+//        }
+//    }
+    
+    func fetchMovieDetails(for movieId: Int) -> AnyPublisher<MovieRepoModel, RequestError> {
+        networkDataSource
+            .fetchMovieDetails(for: movieId)
+            .map { MovieRepoModel(fromModel: $0) }
+            .eraseToAnyPublisher()
     }
     
     func fetchCast(for movieId: Int, completion: @escaping(Result<[CastRepoModel], RequestError>) -> Void) {
@@ -164,32 +172,37 @@ class MovieRepository: MovieRepositoryProtocol {
     }
     
     func getFavoriteMovies(completion: @escaping(Result<[MovieRepoModel], RequestError>) -> Void) {
-        var movies: [MovieRepoModel] = []
-        var counter: Int = 0
-        
-        let completionHandler: (Result<MovieDataModel, RequestError>) -> Void = { [weak self] result in
-            guard let self = self else { return }
-            
-            switch result {
-            case .success(let movie):
-                let mappedMovie = MovieRepoModel(
-                    fromModel: movie,
-                    isFavorite: self.userDefaultsDataSource.favorites.contains(movie.identifier))
-                counter += 1
-                movies.append(mappedMovie)
-            case .failure(let error):
-                print("Error fetching favorites. \(error.localizedDescription)")
-            }
-                        
-            if counter == self.userDefaultsDataSource.favorites.count {
-                completion(.success(movies))
-            }
-        }
-        
-        userDefaultsDataSource.favorites.forEach { movieId in
-            networkDataSource.fetchMovieDetails(for: movieId, completion: completionHandler)
-        }
+//        var movies: [MovieRepoModel] = []
+//        var counter: Int = 0
+//
+//        let completionHandler: (Result<MovieDataModel, RequestError>) -> Void = { [weak self] result in
+//            guard let self = self else { return }
+//
+//            switch result {
+//            case .success(let movie):
+//                let mappedMovie = MovieRepoModel(
+//                    fromModel: movie,
+//                    isFavorite: self.userDefaultsDataSource.favorites.contains(movie.identifier))
+//                counter += 1
+//                movies.append(mappedMovie)
+//            case .failure(let error):
+//                print("Error fetching favorites. \(error.localizedDescription)")
+//            }
+//
+//            if counter == self.userDefaultsDataSource.favorites.count {
+//                completion(.success(movies))
+//            }
+//        }
+//
+//        userDefaultsDataSource.favorites.forEach { movieId in
+//            networkDataSource.fetchMovieDetails(for: movieId, completion: completionHandler)
+//        }
+        completion(.failure(.general))
     }
+    
+//    var favoriteMovies: AnyPublisher<[MovieRepoModel], Never> {
+//
+//    }
     
     func checkIfFavorite(for movieId: Int) -> Bool {
         userDefaultsDataSource

--- a/MovieApp/MovieApp/App/Repository/MovieRepositoryProtocol.swift
+++ b/MovieApp/MovieApp/App/Repository/MovieRepositoryProtocol.swift
@@ -1,3 +1,5 @@
+import Combine
+
 protocol MovieRepositoryProtocol {
     
     func fetchPopularMovies(completion: @escaping (Result<[MovieRepoModel], RequestError>) -> Void)
@@ -6,7 +8,8 @@ protocol MovieRepositoryProtocol {
     
     func fetchTopRatedMovies(completion: @escaping(Result<[MovieRepoModel], RequestError>) -> Void)
         
-    func fetchMovieDetails(for movieId: Int, completion: @escaping(Result<MovieRepoModel, RequestError>) -> Void)
+    //func fetchMovieDetails(for movieId: Int, completion: @escaping(Result<MovieRepoModel, RequestError>) -> Void)
+    func fetchMovieDetails(for movieId: Int) -> AnyPublisher<MovieRepoModel, RequestError>
     
     func fetchCast(for movieId: Int, completion: @escaping(Result<[CastRepoModel], RequestError>) -> Void)
     

--- a/MovieApp/MovieApp/App/Repository/MovieRepositoryProtocol.swift
+++ b/MovieApp/MovieApp/App/Repository/MovieRepositoryProtocol.swift
@@ -9,7 +9,7 @@ protocol MovieRepositoryProtocol {
     func fetchTopRatedMovies(completion: @escaping(Result<[MovieRepoModel], RequestError>) -> Void)
         
     //func fetchMovieDetails(for movieId: Int, completion: @escaping(Result<MovieRepoModel, RequestError>) -> Void)
-    func fetchMovieDetails(for movieId: Int) -> AnyPublisher<MovieRepoModel, RequestError>
+    func fetchMovieDetails(for movieId: Int) -> AnyPublisher<MovieRepoModel, Never>
     
     func fetchCast(for movieId: Int, completion: @escaping(Result<[CastRepoModel], RequestError>) -> Void)
     
@@ -28,7 +28,5 @@ protocol MovieRepositoryProtocol {
     func getMovie(with movieId: Int) -> MovieRepoModel?
     
     func getFavoriteMovies(completion: @escaping(Result<[MovieRepoModel], RequestError>) -> Void)
-    
-    func checkIfFavorite(for movieId: Int) -> Bool
-    
+        
 }

--- a/MovieApp/MovieApp/App/UseCase/MoviesUseCase.swift
+++ b/MovieApp/MovieApp/App/UseCase/MoviesUseCase.swift
@@ -1,3 +1,5 @@
+import Combine
+
 class MoviesUseCase: MoviesUseCaseProtocol {
     
     static let shared: MoviesUseCaseProtocol = MoviesUseCase()
@@ -25,21 +27,34 @@ class MoviesUseCase: MoviesUseCaseProtocol {
             self?.mapResult(result: result, completion: completion)
         }
     }
-    func getMovieDetails(for movieId: Int, completion: @escaping(Result<MovieModel, RequestError>) -> Void) {
-        moviesDataRepo.fetchMovieDetails(for: movieId) { [weak self] result in
-            self?.mapMovieDetailResult(result: result, completion: completion)
-        }
+    
+//    func getMovieDetails(for movieId: Int, completion: @escaping(Result<MovieModel, RequestError>) -> Void) {
+//        moviesDataRepo.fetchMovieDetails(for: movieId) { [weak self] result in
+//            self?.mapMovieDetailResult(result: result, completion: completion)
+//        }
+//    }
+    func getMovieDetails(for movieId: Int) -> AnyPublisher<MovieModel, RequestError> {
+        moviesDataRepo
+            .fetchMovieDetails(for: movieId)
+            .map { MovieModel(fromModel: $0) }
+            .eraseToAnyPublisher()
     }
     
-    func getMovieOverview(for movieId: Int, completion: @escaping(Result<String, RequestError>) -> Void) {
-        moviesDataRepo.fetchMovieDetails(for: movieId) { result in
-            switch result {
-            case .failure(let error):
-                completion(.failure(error))
-            case .success(let movie):
-                completion(.success(movie.overview))
-            }
-        }
+//    func getMovieOverview(for movieId: Int, completion: @escaping(Result<String, RequestError>) -> Void) {
+//        moviesDataRepo.fetchMovieDetails(for: movieId) { result in
+//            switch result {
+//            case .failure(let error):
+//                completion(.failure(error))
+//            case .success(let movie):
+//                completion(.success(movie.overview))
+//            }
+//        }
+//    }
+    func getMovieOverview(for movieId: Int) -> AnyPublisher<String, RequestError> {
+        moviesDataRepo
+            .fetchMovieDetails(for: movieId)
+            .map { $0.overview }
+            .eraseToAnyPublisher()
     }
     
     func getMostPopularCast(for movieId: Int, completion: @escaping(Result<[CastModel], RequestError>) -> Void) {

--- a/MovieApp/MovieApp/App/UseCase/MoviesUseCase.swift
+++ b/MovieApp/MovieApp/App/UseCase/MoviesUseCase.swift
@@ -33,7 +33,7 @@ class MoviesUseCase: MoviesUseCaseProtocol {
 //            self?.mapMovieDetailResult(result: result, completion: completion)
 //        }
 //    }
-    func getMovieDetails(for movieId: Int) -> AnyPublisher<MovieModel, RequestError> {
+    func getMovieDetails(for movieId: Int) -> AnyPublisher<MovieModel, Never> {
         moviesDataRepo
             .fetchMovieDetails(for: movieId)
             .map { MovieModel(fromModel: $0) }
@@ -50,12 +50,6 @@ class MoviesUseCase: MoviesUseCaseProtocol {
 //            }
 //        }
 //    }
-    func getMovieOverview(for movieId: Int) -> AnyPublisher<String, RequestError> {
-        moviesDataRepo
-            .fetchMovieDetails(for: movieId)
-            .map { $0.overview }
-            .eraseToAnyPublisher()
-    }
     
     func getMostPopularCast(for movieId: Int, completion: @escaping(Result<[CastModel], RequestError>) -> Void) {
         moviesDataRepo.fetchCast(for: movieId) { result in
@@ -136,10 +130,6 @@ class MoviesUseCase: MoviesUseCaseProtocol {
         moviesDataRepo.getFavoriteMovies { [weak self] result in
             self?.mapResult(result: result, completion: completion)
         }
-    }
-    
-    func checkIfFavorite(for movieId: Int) -> Bool {
-        moviesDataRepo.checkIfFavorite(for: movieId)
     }
 
 }

--- a/MovieApp/MovieApp/App/UseCase/MoviesUseCaseProtocol.swift
+++ b/MovieApp/MovieApp/App/UseCase/MoviesUseCaseProtocol.swift
@@ -1,3 +1,5 @@
+import Combine
+
 protocol MoviesUseCaseProtocol {
     
     func getPopularMovies(completion: @escaping(Result<[MovieModel], RequestError>) -> Void)
@@ -6,9 +8,11 @@ protocol MoviesUseCaseProtocol {
         
     func getTopRatedMovies(completion: @escaping (Result<[MovieModel], RequestError>) -> Void)
         
-    func getMovieDetails(for movieId: Int, completion: @escaping(Result<MovieModel, RequestError>) -> Void)
+    //func getMovieDetails(for movieId: Int, completion: @escaping(Result<MovieModel, RequestError>) -> Void)
+    func getMovieDetails(for movieId: Int) -> AnyPublisher<MovieModel, RequestError>
     
-    func getMovieOverview(for movieId: Int, completion: @escaping(Result<String, RequestError>) -> Void)
+    //func getMovieOverview(for movieId: Int, completion: @escaping(Result<String, RequestError>) -> Void)
+    func getMovieOverview(for movieId: Int) -> AnyPublisher<String, RequestError>
     
     func getMostPopularCast(for movieId: Int, completion: @escaping(Result<[CastModel], RequestError>) -> Void)
     

--- a/MovieApp/MovieApp/App/UseCase/MoviesUseCaseProtocol.swift
+++ b/MovieApp/MovieApp/App/UseCase/MoviesUseCaseProtocol.swift
@@ -9,10 +9,7 @@ protocol MoviesUseCaseProtocol {
     func getTopRatedMovies(completion: @escaping (Result<[MovieModel], RequestError>) -> Void)
         
     //func getMovieDetails(for movieId: Int, completion: @escaping(Result<MovieModel, RequestError>) -> Void)
-    func getMovieDetails(for movieId: Int) -> AnyPublisher<MovieModel, RequestError>
-    
-    //func getMovieOverview(for movieId: Int, completion: @escaping(Result<String, RequestError>) -> Void)
-    func getMovieOverview(for movieId: Int) -> AnyPublisher<String, RequestError>
+    func getMovieDetails(for movieId: Int) -> AnyPublisher<MovieModel, Never>
     
     func getMostPopularCast(for movieId: Int, completion: @escaping(Result<[CastModel], RequestError>) -> Void)
     
@@ -31,7 +28,5 @@ protocol MoviesUseCaseProtocol {
     func getMovie(with movieId: Int) -> MovieModel?
     
     func getFavoriteMovies(completion: @escaping(Result<[MovieModel], RequestError>) -> Void)
-
-    func checkIfFavorite(for movieId: Int) -> Bool
 
 }


### PR DESCRIPTION
I made api call in `MovieClient` in function `fetchMovieDetails(for movieId: Int) -> AnyPublisher<MovieDetailResponse, RequestError>`.
I still didn't make any changes to `NetworkClient` (Base client), but I plan to do so in the next PR, where I will also deal with adding FavoritesVC to the chain created in this PR.

For now, in `MovieDetailVC`, I've just written sinks viewDidLoad(), but later I will put all the sinks in the separate function called something like `fetchFromPresenter()`.

![simulator_screenshot_DCB73B32-ABBD-4A20-862F-6F1E34C85724](https://user-images.githubusercontent.com/82365531/130039318-ea59f385-e262-4c1b-896c-f5be9647eb00.png)
